### PR TITLE
Update silhouette.js

### DIFF
--- a/src/silhouette.js
+++ b/src/silhouette.js
@@ -40,7 +40,7 @@ function silhouetteSamples(data, labels, reduceFunction) {
   let labelsFreq = countBy(labels);
   let samples = reduceFunction(data, labels, labelsFreq);
   let denom = labels.map((val) => labelsFreq[val] - 1);
-  let intra = samples.intraDist.map((val, ind) => val / denom[ind]);
+  let intra = samples.intraDist.map((val, ind) => denom[ind]? val / denom[ind] : 0);
   let inter = samples.interDist;
   return inter
     .map((val, ind) => val - intra[ind])


### PR DESCRIPTION
A fix for when there's only 1 item in a cluster: Main function returned a NaN score in those cases, since x/0 is NaN. Based on wiki's silhouette definition, I defined 0 in those special cases: 
"Note that a(i) is not clearly defined for clusters with size = 1, in which case we set {\displaystyle s(i)=0}{\displaystyle s(i)=0}. This choice is arbitrary, but neutral in the sense that it is at the midpoint of the bounds, -1 and 1."